### PR TITLE
Removing Python version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = ["Avanish Subbiah <avanishsubbiah1@gmail.com>", "0xMRTT", "David Lapsh
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
-python = "^3.10"
 Pillow = "^9.2.0"
 regex = "*"
 


### PR DESCRIPTION
It isn't based on any reasoning, was probably added automatically by poetry. It fails gradience builds using GNOME's Platform 42 to be able to publish it to Flathub.

Also, can pypi be subsequently updated?